### PR TITLE
Add the height argument to verify in net

### DIFF
--- a/lib/net/pool.js
+++ b/lib/net/pool.js
@@ -2093,7 +2093,7 @@ Pool.prototype._handleHeaders = async function _handleHeaders(peer, packet) {
     const hash = header.hash('hex');
     const height = last.height + 1;
 
-    if (!header.verify()) {
+    if (!header.verify(height)) {
       this.logger.warning(
         'Peer sent an invalid header (%s).',
         peer.hostname());


### PR DESCRIPTION
Block headers require their height in order to validate now. The operand was missed in the network code here leading to a failure to sync.