### PR TITLE
Updated uglify plugin, solves errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "level-js": "^2.2.4",
     "mocha": "^5.2.0",
     "node-loader": "^0.6.0",
-    "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
+    "uglifyjs-webpack-plugin": "^1.1.8",
     "webpack": "^3.5.4"
   },
   "main": "./lib/bcoin.js",

--- a/webpack.browser.js
+++ b/webpack.browser.js
@@ -28,8 +28,10 @@ module.exports = {
         str(env.VCOIN_WORKER_FILE || '/vcoin-worker.js')
     }),
     new UglifyJsPlugin({
-      compress: {
-        warnings: true
+      uglifyOptions:{
+        compress: {
+          warnings: true
+        }
       }
     })
   ]

--- a/webpack.compat.js
+++ b/webpack.compat.js
@@ -35,8 +35,10 @@ module.exports = {
         str(env.BCOIN_WORKER_FILE || '/bcoin-worker.js')
     }),
     new UglifyJsPlugin({
-      compress: {
-        warnings: false
+      uglifyOptions:{
+        compress: {
+          warnings: false
+        }
       }
     })
   ]

--- a/webpack.node.js
+++ b/webpack.node.js
@@ -41,8 +41,10 @@ module.exports = {
     }),
     new webpack.IgnorePlugin(/^utf-8-validate|bufferutil$/),
     new UglifyJsPlugin({
-      compress: {
-        warnings: true
+      uglifyOptions:{
+        compress: {
+          warnings: true
+        }
       }
     })
   ]


### PR DESCRIPTION
Got errors regarding uglify js plugin when attempting to run `npm run webpack`. Found that it was a duplicate of https://github.com/bcoin-org/bcoin/issues/411.